### PR TITLE
Add help flag

### DIFF
--- a/bin/bettercap
+++ b/bin/bettercap
@@ -60,11 +60,11 @@ begin
       ctx.options[:spoofer] = v
     end
 
-    opts.on( '-T', '--target ADDRESS', 'Target ip address, if not specified the whole subnet will be targeted.' ) do |v|
+    opts.on( '-T', '--target ADDRESS', 'Target IP address, if not specified the whole subnet will be targeted.' ) do |v|
       ctx.options[:target] = v
     end
 
-    opts.on( '-O', '--log LOG_FILE', 'Log all messagges into a file, if not specified the log messages will be only print into the shell.' ) do |v|
+    opts.on( '-O', '--log LOG_FILE', 'Log all messages into a file, if not specified the log messages will be only print into the shell.' ) do |v|
       ctx.options[:logfile] = v
     end
 
@@ -100,6 +100,11 @@ begin
 
     opts.on( '--proxy-module MODULE', 'Ruby proxy module to load.' ) do |v|
       ctx.options[:proxy_module] = File.expand_path v
+    end
+
+    opts.on('-h', '--help', 'Display the available options.') do
+      puts opts
+      exit
     end
   end.parse!
 

--- a/bin/bettercap
+++ b/bin/bettercap
@@ -17,7 +17,7 @@ require 'colorize'
 require 'packetfu'
 require 'ipaddr'
 
-Object.send :remove_const, :Config
+Object.send :remove_const, :Config rescue nil
 Config = RbConfig
 
 require 'bettercap/error'


### PR DESCRIPTION
`OptionParser` comes with a pretty good help menu out of the box, so now bettercap has a `--help` flag. Some of the longer help items will be wrapped if you are running in a narrow window, but it's a start.

One concern I have is that the help menu cannot be printed without being run as root – perhaps it would be helpful to allow certain commands to run without requiring elevated privileges.

I was also seeing exceptions being thrown during the call to `remove_const`, so I added a rescue statement to prevent it from taking down the program.

(Also, fixed a couple of typos.)