### PR TITLE
Fixed common error with OSX iface detection

### DIFF
--- a/lib/bettercap/network.rb
+++ b/lib/bettercap/network.rb
@@ -40,6 +40,7 @@ class Network
       out.each do |line|
         if line.include?( Context.get.options[:iface] )
           gw = line.split[1]
+          break if is_ip?(gw)
         end
       end
 


### PR DESCRIPTION
The method #is_ip in the Network class checks for IPv4 addresses only. In OSX, it will often grab the IPv6 address in this loop as it is listed as a second default iface when running `netstat` and will exit false on is_ip?(gw) on line 46. This will exit once it finds the first valid default IPv4 address. 

May be an issue with other environments?