### PR TITLE
remove flush in add_port_redirection

### DIFF
--- a/lib/bettercap/firewalls/linux.rb
+++ b/lib/bettercap/firewalls/linux.rb
@@ -26,10 +26,6 @@ class LinuxFirewall < IFirewall
   end
 
   def add_port_redirection( iface, proto, from, addr, to )
-    # clear nat
-    shell.execute('iptables -t nat -F')
-    # clear
-    shell.execute('iptables -F')
     # post route
     shell.execute('iptables -t nat -I POSTROUTING -s 0/0 -j MASQUERADE')
     # accept all


### PR DESCRIPTION
In Linux, iptables are being cleared when adding every port redirection, so when proxy-https is enabled, the first rule (for http) is added after flushing, but when adding the second rule (for https), iptables are flushed again.

Finally, when exiting, bettercap tries to delete the port redirection rules but http redirection rule doesn't exist. This actually stops the normal flow, and leaves the https redirection rule enabled (!).

```
iptables: No chain/target/match by that name.
/var/lib/gems/2.1.0/gems/bettercap-1.1.4/lib/bettercap/shell.rb:17:in `execute': Error, executing iptables -t nat -D PREROUTING -i wlan0 -p TCP --dport 80 -j REDIRECT --to 8080 (BetterCap::Error)
	from /var/lib/gems/2.1.0/gems/bettercap-1.1.4/lib/bettercap/firewalls/linux.rb:45:in `del_port_redirection'
	from /var/lib/gems/2.1.0/gems/bettercap-1.1.4/lib/bettercap/context.rb:184:in `disable_port_redirection'
	from /var/lib/gems/2.1.0/gems/bettercap-1.1.4/lib/bettercap/context.rb:259:in `finalize'
	from /var/lib/gems/2.1.0/gems/bettercap-1.1.4/bin/bettercap:227:in `<top (required)>'
	from /usr/local/bin/bettercap:23:in `load'
	from /usr/local/bin/bettercap:23:in `<main>'
```