### PR TITLE
Added manual gateway 

### DIFF
--- a/bin/bettercap
+++ b/bin/bettercap
@@ -168,7 +168,7 @@ begin
     Logger.info("Targetting manual gateway #{ctx.gateway}")
   end
   
-	ctx.update_network
+  ctx.update_network
 
   if ctx.options[:target].nil?
     Logger.info( "Targeting the whole subnet #{ctx.network.to_range} ..." ) unless \

--- a/bin/bettercap
+++ b/bin/bettercap
@@ -23,6 +23,10 @@ begin
   OptionParser.new do |opts|
     opts.banner = "Usage: #{$0} [options]"
     opts.version = BetterCap::VERSION
+    
+		opts.on( '-G', '--gateway ADDRESS', 'Manually specify the gateway address, if not specified the current gateway will be retrieved and used. ' ) do |v|
+      ctx.options[:gateway] = v
+    end
 
     opts.on( '-I', '--interface IFACE', 'Network interface name - default: ' + ctx.options[:iface].to_s ) do |v|
       ctx.options[:iface] = v
@@ -157,7 +161,14 @@ begin
 
   Logger.logfile = ctx.options[:logfile]
 
-  ctx.update_network
+
+  if !ctx.options[:gateway].nil?
+    raise BetterCap::Error, "Invalid gateway" if !Network.is_ip?(ctx.options[:gateway])
+    ctx.gateway = ctx.options[:gateway]
+    Logger.info("Targetting manual gateway #{ctx.gateway}")
+  end
+  
+	ctx.update_network
 
   if ctx.options[:target].nil?
     Logger.info( "Targeting the whole subnet #{ctx.network.to_range} ..." ) unless \

--- a/lib/bettercap/context.rb
+++ b/lib/bettercap/context.rb
@@ -36,6 +36,7 @@ class Context
     end
 
     @options = {
+      gateway: nil,
       iface: iface,
       spoofer: 'ARP',
       half_duplex: false,
@@ -114,7 +115,7 @@ class Context
     @firewall = FirewallFactory.get_firewall
     @ifconfig = PacketFu::Utils.ifconfig @options[:iface]
     @network  = @ifconfig[:ip4_obj]
-    @gateway  = Network.get_gateway
+    @gateway  = Network.get_gateway if @gateway.nil?
 
     raise BetterCap::Error, "Could not determine IPv4 address of '#{@options[:iface]}' interface." unless !@network.nil?
 


### PR DESCRIPTION
Hi everyone, I tought it might be useful to extend the tool in order to be able to use it in a scenario where a gateway is not present or is not part of the MITM. I was performing some tests on a small network and I needed to perform a MITM attack between two PCs on the same LAN without involving the current gateway. So I slightly modified bettercap in order to be able to specify the gateway address in the command line (I'm not a skilled ruby programmer, hope I'm not shaking too much the code). 
Technically calling it gateway is not correct, since ... well ... is not a gateway :), but I coulnd't come up with a better name\description without rewriting everywhere for refactoring the name "gateway" with a more general one.
What do you think?