### PR TITLE
Added missing dependency network_interface to gemspec.

### DIFF
--- a/bettercap.gemspec
+++ b/bettercap.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency( 'colorize', '~> 0.7.5' )
   gem.add_dependency( 'packetfu', '~> 1.1.10' )
   gem.add_dependency( 'pcaprub', '~> 0.12.0' )
+  gem.add_dependency( 'network_interface', '~> 0.0.1' )
 
   gem.add_development_dependency( 'minitest' )
 


### PR DESCRIPTION
Bettercap is failing to run in BlackArch as it's installed from gemspec which seemed to be missing the network_interface gem.