### PR TITLE
Fix bug in Spoofer::get_by_name

### DIFF
--- a/lib/bettercap/factories/parser.rb
+++ b/lib/bettercap/factories/parser.rb
@@ -55,7 +55,7 @@ class Parser
 
           require_relative "#{@@path}#{file}"
 
-          loaded << Kernel.const_get("BetterCap::Parsers::#{cname.capitalize}").new
+          loaded << Kernel.const_get("BetterCap").const_get("Parsers").const_get("#{cname.capitalize}").new
         end
       end
       loaded

--- a/lib/bettercap/factories/spoofer.rb
+++ b/lib/bettercap/factories/spoofer.rb
@@ -37,7 +37,7 @@ class Spoofer
 
       require_relative "../spoofers/#{name}"
 
-      Kernel.const_get("BetterCap::Spoofers::#{name.capitalize}").new
+      Kernel.const_get("BetterCap").const_get("Spoofers").const_get("#{name.capitalize}").new
     end
 
     private

--- a/lib/bettercap/network.rb
+++ b/lib/bettercap/network.rb
@@ -135,7 +135,7 @@ class << self
 
   def start_agents( ctx )
     [ 'Icmp', 'Udp', 'Arp' ].each do |name|
-      Kernel.const_get("BetterCap::Discovery::Agents::#{name}").new( ctx )
+      Kernel.const_get("BetterCap").const_get("Discovery").const_get("Agents").const_get(name).new( ctx )
     end
     ctx.packets.wait_empty( ctx.timeout )
   end


### PR DESCRIPTION
On at least one platform (Linux), const_get with a fully qualified name
was not working as expected.