### PR TITLE
Add sniffer/parsers/SNPP

### DIFF
--- a/lib/bettercap/sniffer/parsers/snpp.rb
+++ b/lib/bettercap/sniffer/parsers/snpp.rb
@@ -1,0 +1,38 @@
+=begin
+
+BETTERCAP
+
+Author : Simone 'evilsocket' Margaritelli
+Email  : evilsocket@gmail.com
+Blog   : http://www.evilsocket.net/
+
+This project is released under the GPL 3 license.
+
+=end
+require 'bettercap/sniffer/parsers/base'
+
+module BetterCap
+module Parsers
+# Simple Network Paging Protocol (SNPP) authentication parser.
+class Snpp < Base
+  def initialize
+    @name = 'SNPP'
+  end
+  def on_packet( pkt )
+    begin
+      if pkt.tcp_dst == 444
+        lines = pkt.to_s.split(/\r?\n/)
+        lines.each do |line|
+          if line =~ /LOGIn\s+(.+)\s+(.+)$/
+            user = $1
+            pass = $2
+            StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
+          end
+        end
+      end
+    rescue
+    end
+  end
+end
+end
+end


### PR DESCRIPTION
Sniff clear text credentials from Simple Network Paging Protocol (SNPP) connections.

Not sure if you want to add this. Tested with a fake server (netcat) due to lack of a test server.

Implemented based on RFC:

* https://tools.ietf.org/html/rfc1861
* https://en.wikipedia.org/wiki/Simple_Network_Paging_Protocol
