### PR TITLE
Use sub! with block to avoid strange sub! behaviour when data contains  the sequence backslash-backtick

### DIFF
--- a/lib/bettercap/proxy/http/modules/injectcss.rb
+++ b/lib/bettercap/proxy/http/modules/injectcss.rb
@@ -67,10 +67,12 @@ class InjectCSS < BetterCap::Proxy::HTTP::Module
       BetterCap::Logger.info "[#{'INJECTCSS'.green}] Injecting CSS #{@@cssdata.nil?? "URL" : "file"} into #{request.to_url}"
       # inject URL
       if @@cssdata.nil?
-        response.body.sub!( '</head>', "  <link rel=\"stylesheet\" href=\"#{@cssurl}\"></script></head>" )
+	 replacement = "  <link rel=\"stylesheet\" href=\"#{@cssurl}\"></script></head> "
+        response.body.sub!( '</head>', {replacement} )
       # inject data
       else
-        response.body.sub!( '</head>', "#{@@cssdata}</head>" )
+	 replacement = "#{@@cssdata}</head> "
+        response.body.sub!( '</head>', {replacement} )
       end
     end
   end

--- a/lib/bettercap/proxy/http/modules/injecthtml.rb
+++ b/lib/bettercap/proxy/http/modules/injecthtml.rb
@@ -55,9 +55,11 @@ class InjectHTML < BetterCap::Proxy::HTTP::Module
       BetterCap::Logger.info "[#{'INJECTHTML'.green}] Injecting HTML code into #{request.to_url}"
 
       if @@data.nil?
-        response.body.sub!( '</body>', "<iframe src=\"#{@@iframe}\" frameborder=\"0\" height=\"0\" width=\"0\"></iframe></body>" )
+	 replacement = "<iframe src=\"#{@@iframe}\" frameborder=\"0\" height=\"0\" width=\"0\"></iframe></body>"
+        response.body.sub!( '</body>', {replacement} )
       else
-        response.body.sub!( '</body>', "#{@@data}</body>" )
+	 replacement = "#{@@data}</body>"
+        response.body.sub!( '</body>', {replacement} )
       end
     end
   end

--- a/lib/bettercap/proxy/http/modules/injectjs.rb
+++ b/lib/bettercap/proxy/http/modules/injectjs.rb
@@ -67,10 +67,12 @@ class InjectJS < BetterCap::Proxy::HTTP::Module
       BetterCap::Logger.info "[#{'INJECTJS'.green}] Injecting javascript #{@@jsdata.nil?? "URL" : "file"} into #{request.to_url}"
       # inject URL
       if @@jsdata.nil?
-        response.body.sub!( '</head>', "<script src=\"#{@@jsurl}\" type=\"text/javascript\"></script></head>" )
+	 replacement =  "<script src=\"#{@@jsurl}\" type=\"text/javascript\"></script></head>"
+        response.body.sub!( '</head>', {replacement} )
       # inject data
       else
-        response.body.sub!( '</head>', "#{@@jsdata}</head>" )
+	 replacement = "#{@@jsdata}</head>" 
+        response.body.sub!( '</head>', {replacement} )
       end
     end
   end


### PR DESCRIPTION
Let test1.rb be:
haystack = "replace me"
needle = "me"
haystack.sub!("me", "you \\`")
print haystack
print "\n

The output is:
replace you replace 

Let test2.rb be:
haystack = "replace me"
needle = "me"
replacement = "you \\`"
haystack.sub!("me") { replacement }
print haystack
print "\n"

The output is:
replace you \`

The PR solves this strange sub! behaviour.