### PR TITLE
Remove redundant requires, minor update to syntax using rubocop

### DIFF
--- a/lib/bettercap.rb
+++ b/lib/bettercap.rb
@@ -17,53 +17,41 @@
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
-require 'base64'
+require 'packetfu'
+require 'em-proxy'
+require 'webrick'
+require 'rubydns'
 require 'colorize'
-require 'digest'
-require 'ipaddr'
 require 'json'
 require 'net/dns'
 require 'net/http'
-require 'openssl'
 require 'optparse'
-require 'packetfu'
-require 'pcaprub'
-require 'resolv'
-require 'rubydns'
-require 'socket'
-require 'stringio'
-require 'thread'
-require 'uri'
-require 'webrick'
-require 'zlib'
-require 'em-proxy'
 
 Object.send :remove_const, :Config rescue nil
 Config = RbConfig
 
-def bettercap_autoload( path = '' )
+def bettercap_autoload(path = '')
   dir    = File.dirname(__FILE__) + "/bettercap/#{path}"
   deps   = []
   files  = []
   monkey = []
 
-  Dir[dir+"**/*.rb"].each do |filename|
-    filename = filename.gsub( dir, '' ).gsub('.rb', '')
+  Dir[dir + '**/*.rb'].each do |filename|
+    filename = filename.gsub(dir, '').gsub('.rb', '')
     filename = "bettercap/#{path}#{filename}"
 
+    next if filename.include?('proxy/http/modules')
     # Proxy modules must be loaded at runtime.
-    unless filename.include?('proxy/http/modules')
-      if filename.end_with?('/base') or filename.include?('pluggable')
-        deps << filename
-      elsif filename.include?('monkey')
-        monkey << filename
-      else
-        files << filename
-      end
+    if filename.end_with?('/base') || filename.include?('pluggable')
+      deps << filename
+    elsif filename.include?('monkey')
+      monkey << filename
+    else
+      files << filename
     end
   end
 
-  ( deps + files + monkey ).each do |file|
+  (deps + files + monkey).each do |file|
     require file
   end
 end


### PR DESCRIPTION
Optimized require statements to remove redundant gem dependencies.

Updated “’s and some spacing changes using rubocop as a guide.

Changed unless filename.include?('proxy/http/modules') to a next
statement instead.