### PR TITLE
Fix missing rainbow option

### DIFF
--- a/bettercap.gemspec
+++ b/bettercap.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.homepage = %q{http://github.com/evilsocket/bettercap}
 
   gem.add_dependency( 'colorize', '~> 0.8.0' )
+  gem.add_dependency( 'lolize', '~> 0.0.3' )
   gem.add_dependency( 'packetfu', '~> 1.1', '>= 1.1.10' )
   gem.add_dependency( 'pcaprub', '~> 0.12', '>= 0.12.0' )
   gem.add_dependency( 'network_interface', '~> 0.0', '>= 0.0.1' )

--- a/lib/bettercap/options/core_options.rb
+++ b/lib/bettercap/options/core_options.rb
@@ -106,7 +106,7 @@ class CoreOptions
       @check_updates = true
     end
     
-    opts.on( '-R', '--rainbows', 'Rainbows output, because that\'s a really helpful thing to have' ) do
+    opts.on( '-R', '--rainbows', 'Rainbow output, because that\'s a really helpful thing to have.' ) do
       require 'lolize/auto'
     end
 

--- a/lib/bettercap/options/core_options.rb
+++ b/lib/bettercap/options/core_options.rb
@@ -132,6 +132,9 @@ class CoreOptions
       @silent = true
     end
 
+    opts.on( '-R', '--rainbows', 'Rainbows output, because that\'s a really helpful thing to have' ) do
+      require 'lolize/auto'
+    end
   end
 
   def validate!

--- a/lib/bettercap/options/core_options.rb
+++ b/lib/bettercap/options/core_options.rb
@@ -105,6 +105,10 @@ class CoreOptions
     opts.on( '--check-updates', 'Will check if any update is available and then exit.' ) do
       @check_updates = true
     end
+    
+    opts.on( '-R', '--rainbows', 'Rainbows output, because that\'s a really helpful thing to have' ) do
+      require 'lolize/auto'
+    end
 
     opts.on( '-h', '--help', 'Display the available options.') do
       puts opts
@@ -132,9 +136,6 @@ class CoreOptions
       @silent = true
     end
 
-    opts.on( '-R', '--rainbows', 'Rainbows output, because that\'s a really helpful thing to have' ) do
-      require 'lolize/auto'
-    end
   end
 
   def validate!


### PR DESCRIPTION

There was no rainbow option. Fixing that before someone’s feelings gets
hurt.

## Why you would want this?
It look's awesome:
![totes put this in logging on accident first](https://cloud.githubusercontent.com/assets/14850816/21284306/001dadac-c3e6-11e6-8e05-3b127273905f.png)

It's a pretty easy thing to add. I really like it.

## More of This
![we can be like this when using bettercap](https://cloud.githubusercontent.com/assets/14850816/21284324/49a4d978-c3e6-11e6-9f6a-793a29111f90.gif)

![hopefully I didn't spell anything wrong](https://cloud.githubusercontent.com/assets/14850816/21284376/42c3c3fc-c3e7-11e6-8722-fc8edddbfb7e.png)

## Advantages
Ettercap doesn't have a rainbow option. This could be a **another** awesome point for bettercap. I also just _really_ like this. I really want this. It's fine if I don't get this ... Plus, it's optional, so it doesn't necessarily hurt anyone. And since it's pretty trivial to implement, we can take it out if it does end up being some crazy disaster. Which I don't think it will be. 

## Disadvantages
There's no real disadvantages. You can argue some practicalities, but, like, it's beautiful. 

## How it Works
Lolize just hooks to standard out / standard error and gives a rainbow output for bettercap when the `-R` or `--rainbows` option is used. 

### Really?
Yeah. I just really like this.