### PR TITLE
Rescue from on_packet method in sniffers

### DIFF
--- a/lib/bettercap/sniffer/parsers/asterisk.rb
+++ b/lib/bettercap/sniffer/parsers/asterisk.rb
@@ -18,18 +18,16 @@ class Asterisk  < Base
     @name = 'Asterisk'
   end
   def on_packet( pkt )
-    begin
-      if pkt.tcp_dst == 5038
-        if pkt.to_s =~ /action:\s+login\r?\n/i
-          if pkt.to_s =~ /username:\s+(.+?)\r?\n/i && pkt.to_s =~ /secret:\s+(.+?)\r?\n/i
-            user = pkt.to_s.scan(/username:\s+(.+?)\r?\n/i).flatten.first
-            pass = pkt.to_s.scan(/secret:\s+(.+?)\r?\n/i).flatten.first
-            StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
-          end
+    if pkt.tcp_dst == 5038
+      if pkt.to_s =~ /action:\s+login\r?\n/i
+        if pkt.to_s =~ /username:\s+(.+?)\r?\n/i && pkt.to_s =~ /secret:\s+(.+?)\r?\n/i
+          user = pkt.to_s.scan(/username:\s+(.+?)\r?\n/i).flatten.first
+          pass = pkt.to_s.scan(/secret:\s+(.+?)\r?\n/i).flatten.first
+          StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
         end
       end
-    rescue
     end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/dhcp.rb
+++ b/lib/bettercap/sniffer/parsers/dhcp.rb
@@ -16,30 +16,29 @@ module Parsers
 # DHCP packets and authentication parser.
 class DHCP < Base
   def on_packet( pkt )
-    begin
-      if pkt.udp_dst == 67 or pkt.udp_dst == 68
-        packet = Network::Protos::DHCP::Packet.parse( pkt.payload )
-        unless packet.nil?
-          auth = packet.authentication
-          cid  = auth.nil?? nil : packet.client_identifier
-          msg  = "[#{packet.type.yellow}] #{'Transaction-ID'.green}=#{sprintf( "0x%X", packet.xid ).yellow}"
+    if pkt.udp_dst == 67 or pkt.udp_dst == 68
+      packet = Network::Protos::DHCP::Packet.parse( pkt.payload )
+      unless packet.nil?
+        auth = packet.authentication
+        cid  = auth.nil?? nil : packet.client_identifier
+        msg  = "[#{packet.type.yellow}] #{'Transaction-ID'.green}=#{sprintf( "0x%X", packet.xid ).yellow}"
 
-          unless cid.nil?
-            msg += " #{'Client-ID'.green}='#{cid.yellow}'"
-          end
-
-          unless auth.nil?
-            msg += "\n#{'AUTHENTICATION'.green}:\n\n"
-            auth.each do |k,v|
-              msg += "  #{k.blue} : #{v.yellow}\n"
-            end
-            msg += "\n"
-          end
-
-          StreamLogger.log_raw( pkt, 'DHCP', msg )
+        unless cid.nil?
+          msg += " #{'Client-ID'.green}='#{cid.yellow}'"
         end
+
+        unless auth.nil?
+          msg += "\n#{'AUTHENTICATION'.green}:\n\n"
+          auth.each do |k,v|
+            msg += "  #{k.blue} : #{v.yellow}\n"
+          end
+          msg += "\n"
+        end
+
+        StreamLogger.log_raw( pkt, 'DHCP', msg )
       end
-    rescue; end
+    end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/dict.rb
+++ b/lib/bettercap/sniffer/parsers/dict.rb
@@ -18,19 +18,17 @@ class Dict < Base
     @name = 'DICT'
   end
   def on_packet( pkt )
-    begin
-      if pkt.tcp_dst == 2628
-        lines = pkt.to_s.split(/\r?\n/)
-        lines.each do |line|
-          if line =~ /AUTH\s+(.+)\s+(.+)$/
-            user = $1
-            pass = $2
-            StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
-          end
+    if pkt.tcp_dst == 2628
+      lines = pkt.to_s.split(/\r?\n/)
+      lines.each do |line|
+        if line =~ /AUTH\s+(.+)\s+(.+)$/
+          user = $1
+          pass = $2
+          StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
         end
       end
-    rescue
     end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/https.rb
+++ b/lib/bettercap/sniffer/parsers/https.rb
@@ -19,27 +19,25 @@ class Https < Base
   @@lock = Mutex.new
 
   def on_packet( pkt )
-    begin
-      # poor man's TLS Client Hello with SNI extension parser :P
-      if pkt.respond_to?(:tcp_dst) and \
-         pkt.payload[0] == "\x16" and \
-         pkt.payload[1] == "\x03" and \
-         pkt.payload =~ /\x00\x00.{4}\x00.{2}([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})\x00/
-        hostname = $1
-        if pkt.tcp_dst != 443
-          hostname += ":#{pkt.tcp_dst}"
-        end
-
-        @@lock.synchronize {
-          if @@prev.nil? or @@prev != hostname
-            StreamLogger.log_raw( pkt, 'HTTPS', "https://#{hostname}/" )
-            @@prev = hostname
-          end
-        }
+    # poor man's TLS Client Hello with SNI extension parser :P
+    if pkt.respond_to?(:tcp_dst) and \
+      pkt.payload[0] == "\x16" and \
+      pkt.payload[1] == "\x03" and \
+      pkt.payload =~ /\x00\x00.{4}\x00.{2}([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})\x00/
+      hostname = $1
+      if pkt.tcp_dst != 443
+        hostname += ":#{pkt.tcp_dst}"
       end
-    rescue; end
-  end
 
+      @@lock.synchronize {
+        if @@prev.nil? or @@prev != hostname
+          StreamLogger.log_raw( pkt, 'HTTPS', "https://#{hostname}/" )
+          @@prev = hostname
+        end
+      }
+    end
+  rescue
+  end
 end
 end
 end

--- a/lib/bettercap/sniffer/parsers/mpd.rb
+++ b/lib/bettercap/sniffer/parsers/mpd.rb
@@ -18,18 +18,16 @@ class Mpd < Base
     @name = 'MPD'
   end
   def on_packet( pkt )
-    begin
-      if pkt.tcp_dst == 6600
-        lines = pkt.to_s.split(/\r?\n/)
-        lines.each do |line|
-          if line =~ /password\s+(.+)$/
-            pass = $1
-            StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
-          end
+    if pkt.tcp_dst == 6600
+      lines = pkt.to_s.split(/\r?\n/)
+      lines.each do |line|
+        if line =~ /password\s+(.+)$/
+          pass = $1
+          StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
         end
       end
-    rescue
     end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/redis.rb
+++ b/lib/bettercap/sniffer/parsers/redis.rb
@@ -19,21 +19,19 @@ class Redis < Base
     @name = 'REDIS'
   end
   def on_packet( pkt )
-    begin
-      if pkt.tcp_dst == 6379
-        lines = pkt.to_s.split(/\r?\n/)
-        lines.each do |line|
-          if line =~ /config\s+set\s+requirepass\s+(.+)$/i
-            pass = "#{$1}"
-            StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
-          elsif line =~ /AUTH\s+(.+)$/i
-            pass = "#{$1}"
-            StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
-          end
+    if pkt.tcp_dst == 6379
+      lines = pkt.to_s.split(/\r?\n/)
+      lines.each do |line|
+        if line =~ /config\s+set\s+requirepass\s+(.+)$/i
+          pass = "#{$1}"
+          StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
+        elsif line =~ /AUTH\s+(.+)$/i
+          pass = "#{$1}"
+          StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
         end
       end
-    rescue
     end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/rlogin.rb
+++ b/lib/bettercap/sniffer/parsers/rlogin.rb
@@ -19,27 +19,25 @@ class Rlogin < Base
     @name = 'RLOGIN'
   end
   def on_packet( pkt )
-    begin
-      if pkt.tcp_dst == 513
-        # rlogin packet data = 0x00[client-username]0x00<server-username>0x00<terminal/speed>0x00
+    if pkt.tcp_dst == 513
+      # rlogin packet data = 0x00[client-username]0x00<server-username>0x00<terminal/speed>0x00
 
-        # if client username, server username and terminal/speed were supplied...
-        # regex starts at client username as the first null byte is stripped from pkt.payload.to_s
-        if pkt.payload.to_s =~ /\A([a-z0-9_-]+)\x00([a-z0-9_-]+)\x00([a-z0-9_-]+\/[0-9]+)\x00\Z/i
-          client_user = $1
-          server_user = $2
-          terminal = $3
-          StreamLogger.log_raw( pkt, @name, "client-username=#{client_user} server-username=#{server_user} terminal=#{terminal}" )
-        # else, if only server username and terminal/speed were supplied...
-        # regex starts at 0x00 as the first null byte is stripped from pkt.payload.to_s and the client username is empty
-        elsif pkt.payload.to_s =~ /\A\x00([a-z0-9_-]+)\x00([a-z0-9_-]+\/[0-9]+)\x00\Z/i
-          server_user = $1
-          terminal = $2
-          StreamLogger.log_raw( pkt, @name, "server-username=#{server_user} terminal=#{terminal}" )
-        end
+      # if client username, server username and terminal/speed were supplied...
+      # regex starts at client username as the first null byte is stripped from pkt.payload.to_s
+      if pkt.payload.to_s =~ /\A([a-z0-9_-]+)\x00([a-z0-9_-]+)\x00([a-z0-9_-]+\/[0-9]+)\x00\Z/i
+        client_user = $1
+        server_user = $2
+        terminal = $3
+        StreamLogger.log_raw( pkt, @name, "client-username=#{client_user} server-username=#{server_user} terminal=#{terminal}" )
+      # else, if only server username and terminal/speed were supplied...
+      # regex starts at 0x00 as the first null byte is stripped from pkt.payload.to_s and the client username is empty
+      elsif pkt.payload.to_s =~ /\A\x00([a-z0-9_-]+)\x00([a-z0-9_-]+\/[0-9]+)\x00\Z/i
+        server_user = $1
+        terminal = $2
+        StreamLogger.log_raw( pkt, @name, "server-username=#{server_user} terminal=#{terminal}" )
       end
-    rescue
     end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/snmp.rb
+++ b/lib/bettercap/sniffer/parsers/snmp.rb
@@ -22,23 +22,22 @@ module Parsers
 # SNMP community string parser.
 class SNMP < Base
   def on_packet( pkt )
-    begin
-      if pkt.udp_dst == 161
+    if pkt.udp_dst == 161
+      packet = Network::Protos::SNMP::Packet.parse( pkt.payload )
 
-        packet = Network::Protos::SNMP::Packet.parse( pkt.payload )
-        unless packet.nil?
-        	if packet.snmp_version_number.to_i == 0
-        	  snmp_version = 'v1'
-        	else
-        	  snmp_version = 'n/a'
-        	end
-
-          msg = "[#{'Version:'.green} #{snmp_version}] [#{'Community:'.green} #{packet.snmp_community_string.map { |x| x.chr }.join.yellow}]"
-
-          StreamLogger.log_raw( pkt, 'SNMP', msg )
+      unless packet.nil?
+        if packet.snmp_version_number.to_i == 0
+          snmp_version = 'v1'
+        else
+          snmp_version = 'n/a'
         end
+
+        msg = "[#{'Version:'.green} #{snmp_version}] [#{'Community:'.green} #{packet.snmp_community_string.map { |x| x.chr }.join.yellow}]"
+
+        StreamLogger.log_raw( pkt, 'SNMP', msg )
       end
-    rescue; end
+    end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/snpp.rb
+++ b/lib/bettercap/sniffer/parsers/snpp.rb
@@ -19,19 +19,17 @@ class Snpp < Base
     @name = 'SNPP'
   end
   def on_packet( pkt )
-    begin
-      if pkt.tcp_dst == 444
-        lines = pkt.to_s.split(/\r?\n/)
-        lines.each do |line|
-          if line =~ /LOGIn\s+(.+)\s+(.+)$/
-            user = $1
-            pass = $2
-            StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
-          end
+    if pkt.tcp_dst == 444
+      lines = pkt.to_s.split(/\r?\n/)
+      lines.each do |line|
+        if line =~ /LOGIn\s+(.+)\s+(.+)$/
+          user = $1
+          pass = $2
+          StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
         end
       end
-    rescue
     end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/teamtalk.rb
+++ b/lib/bettercap/sniffer/parsers/teamtalk.rb
@@ -18,22 +18,20 @@ class TeamTalk < Base
     @name = 'TeamTalk'
   end
   def on_packet( pkt )
-    begin
-      if pkt.tcp_dst == 10333 || pkt.udp_dst == 10333
-        lines = pkt.to_s.split(/\r?\n/)
-        lines.each do |line|
-          if line =~ /login\s+/
-            if line =~ /username=/ && line =~ /password=/
-              version = line.scan(/version="?([\d\.]+)"?\s/).flatten.first
-              user = line.scan(/username="?(.*?)"?\s/).flatten.first
-              pass = line.scan(/password="?(.*?)"?\s/).flatten.first
-              StreamLogger.log_raw( pkt, @name, "#{'version'.blue}=#{version} username=#{user} password=#{pass}" )
-            end
+    if pkt.tcp_dst == 10333 || pkt.udp_dst == 10333
+      lines = pkt.to_s.split(/\r?\n/)
+      lines.each do |line|
+        if line =~ /login\s+/
+          if line =~ /username=/ && line =~ /password=/
+            version = line.scan(/version="?([\d\.]+)"?\s/).flatten.first
+            user = line.scan(/username="?(.*?)"?\s/).flatten.first
+            pass = line.scan(/password="?(.*?)"?\s/).flatten.first
+            StreamLogger.log_raw( pkt, @name, "#{'version'.blue}=#{version} username=#{user} password=#{pass}" )
           end
         end
       end
-    rescue
     end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/teamviewer.rb
+++ b/lib/bettercap/sniffer/parsers/teamviewer.rb
@@ -16,14 +16,13 @@ module Parsers
 # MySQL authentication parser.
 class TeamViewer < Base
   def on_packet( pkt )
-    begin
-      if pkt.tcp_dst == 5938 or pkt.tcp_src == 5938
-        packet = Network::Protos::TeamViewer::Packet.parse( pkt.payload )
-        unless packet.nil?
-          StreamLogger.log_raw( pkt, 'TEAMVIEWER', "#{'version'.blue}=#{packet.version.yellow} #{'command'.blue}=#{packet.command.yellow}"  )
-        end
+    if pkt.tcp_dst == 5938 or pkt.tcp_src == 5938
+      packet = Network::Protos::TeamViewer::Packet.parse( pkt.payload )
+      unless packet.nil?
+        StreamLogger.log_raw( pkt, 'TEAMVIEWER', "#{'version'.blue}=#{packet.version.yellow} #{'command'.blue}=#{packet.command.yellow}"  )
       end
-    rescue; end
+    end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/whatsapp.rb
+++ b/lib/bettercap/sniffer/parsers/whatsapp.rb
@@ -20,13 +20,12 @@ module Parsers
 # WhatsApp traffic parser.
 class Whatsapp < Base
   def on_packet( pkt )
-    begin
-      if ( pkt.tcp_dst == 443 or pkt.tcp_dst == 5222 or pkt.tcp_dst == 5223 ) and pkt.payload =~ /^WA.*?([a-zA-Z\-\.0-9]+).*?([0-9]+)/
-        version = $1
-        phone = $2
-        StreamLogger.log_raw( pkt, 'WHATSAPP', "#{'phone'.green}=#{phone.yellow} #{'version'.green}=#{version.yellow}" )
-      end
-    rescue; end
+    if ( pkt.tcp_dst == 443 or pkt.tcp_dst == 5222 or pkt.tcp_dst == 5223 ) and pkt.payload =~ /^WA.*?([a-zA-Z\-\.0-9]+).*?([0-9]+)/
+      version = $1
+      phone = $2
+      StreamLogger.log_raw( pkt, 'WHATSAPP', "#{'phone'.green}=#{phone.yellow} #{'version'.green}=#{version.yellow}" )
+    end
+  rescue
   end
 end
 end


### PR DESCRIPTION
Minor code cleanup; rescues from `on_packet` method in sniffers, rather than using `begin; rescue` blocks.

Keeps the code closer to the left margin.

Results in slightly smaller file sizes.
