### PR TITLE
Use return unless guard clause in sniffers

### DIFF
--- a/lib/bettercap/sniffer/parsers/asterisk.rb
+++ b/lib/bettercap/sniffer/parsers/asterisk.rb
@@ -18,14 +18,13 @@ class Asterisk  < Base
     @name = 'Asterisk'
   end
   def on_packet( pkt )
-    if pkt.tcp_dst == 5038
-      if pkt.to_s =~ /action:\s+login\r?\n/i
-        if pkt.to_s =~ /username:\s+(.+?)\r?\n/i && pkt.to_s =~ /secret:\s+(.+?)\r?\n/i
-          user = pkt.to_s.scan(/username:\s+(.+?)\r?\n/i).flatten.first
-          pass = pkt.to_s.scan(/secret:\s+(.+?)\r?\n/i).flatten.first
-          StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
-        end
-      end
+    return unless pkt.tcp_dst == 5038
+    return unless pkt.to_s =~ /action:\s+login\r?\n/i
+
+    if pkt.to_s =~ /username:\s+(.+?)\r?\n/i && pkt.to_s =~ /secret:\s+(.+?)\r?\n/i
+      user = pkt.to_s.scan(/username:\s+(.+?)\r?\n/i).flatten.first
+      pass = pkt.to_s.scan(/secret:\s+(.+?)\r?\n/i).flatten.first
+      StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
     end
   rescue
   end

--- a/lib/bettercap/sniffer/parsers/dhcp.rb
+++ b/lib/bettercap/sniffer/parsers/dhcp.rb
@@ -16,28 +16,29 @@ module Parsers
 # DHCP packets and authentication parser.
 class DHCP < Base
   def on_packet( pkt )
-    if pkt.udp_dst == 67 or pkt.udp_dst == 68
-      packet = Network::Protos::DHCP::Packet.parse( pkt.payload )
-      unless packet.nil?
-        auth = packet.authentication
-        cid  = auth.nil?? nil : packet.client_identifier
-        msg  = "[#{packet.type.yellow}] #{'Transaction-ID'.green}=#{sprintf( "0x%X", packet.xid ).yellow}"
+    return unless (pkt.udp_dst == 67 || pkt.udp_dst == 68)
 
-        unless cid.nil?
-          msg += " #{'Client-ID'.green}='#{cid.yellow}'"
-        end
+    packet = Network::Protos::DHCP::Packet.parse( pkt.payload )
 
-        unless auth.nil?
-          msg += "\n#{'AUTHENTICATION'.green}:\n\n"
-          auth.each do |k,v|
-            msg += "  #{k.blue} : #{v.yellow}\n"
-          end
-          msg += "\n"
-        end
+    return if packet.nil?
 
-        StreamLogger.log_raw( pkt, 'DHCP', msg )
-      end
+    auth = packet.authentication
+    cid  = auth.nil?? nil : packet.client_identifier
+    msg  = "[#{packet.type.yellow}] #{'Transaction-ID'.green}=#{sprintf( "0x%X", packet.xid ).yellow}"
+
+    unless cid.nil?
+      msg += " #{'Client-ID'.green}='#{cid.yellow}'"
     end
+
+    unless auth.nil?
+      msg += "\n#{'AUTHENTICATION'.green}:\n\n"
+      auth.each do |k,v|
+        msg += "  #{k.blue} : #{v.yellow}\n"
+      end
+      msg += "\n"
+    end
+
+    StreamLogger.log_raw( pkt, 'DHCP', msg )
   rescue
   end
 end

--- a/lib/bettercap/sniffer/parsers/dict.rb
+++ b/lib/bettercap/sniffer/parsers/dict.rb
@@ -18,14 +18,14 @@ class Dict < Base
     @name = 'DICT'
   end
   def on_packet( pkt )
-    if pkt.tcp_dst == 2628
-      lines = pkt.to_s.split(/\r?\n/)
-      lines.each do |line|
-        if line =~ /AUTH\s+(.+)\s+(.+)$/
-          user = $1
-          pass = $2
-          StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
-        end
+    return unless pkt.tcp_dst == 2628
+
+    lines = pkt.to_s.split(/\r?\n/)
+    lines.each do |line|
+      if line =~ /AUTH\s+(.+)\s+(.+)$/
+        user = $1
+        pass = $2
+        StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
       end
     end
   rescue

--- a/lib/bettercap/sniffer/parsers/mpd.rb
+++ b/lib/bettercap/sniffer/parsers/mpd.rb
@@ -18,13 +18,13 @@ class Mpd < Base
     @name = 'MPD'
   end
   def on_packet( pkt )
-    if pkt.tcp_dst == 6600
-      lines = pkt.to_s.split(/\r?\n/)
-      lines.each do |line|
-        if line =~ /password\s+(.+)$/
-          pass = $1
-          StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
-        end
+    return unless pkt.tcp_dst == 6600
+
+    lines = pkt.to_s.split(/\r?\n/)
+    lines.each do |line|
+      if line =~ /password\s+(.+)$/
+        pass = $1
+        StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
       end
     end
   rescue

--- a/lib/bettercap/sniffer/parsers/post.rb
+++ b/lib/bettercap/sniffer/parsers/post.rb
@@ -17,16 +17,15 @@ module Parsers
 class Post < Base
   def on_packet( pkt )
     s = pkt.to_s
-    if s =~ /POST\s+[^\s]+\s+HTTP.+/
-      begin
-        req = BetterCap::Proxy::HTTP::Request.parse(pkt.payload)
-        # the packet could be incomplete
-        unless req.body.nil? or req.body.empty?
-          StreamLogger.log_raw( pkt, "POST", req.to_url(1000) )
-          StreamLogger.log_post( req )
-        end
-      rescue; end
+    return unless s =~ /POST\s+[^\s]+\s+HTTP.+/
+
+    req = BetterCap::Proxy::HTTP::Request.parse(pkt.payload)
+    # the packet could be incomplete
+    unless req.body.nil? or req.body.empty?
+      StreamLogger.log_raw( pkt, "POST", req.to_url(1000) )
+      StreamLogger.log_post( req )
     end
+  rescue
   end
 end
 end

--- a/lib/bettercap/sniffer/parsers/redis.rb
+++ b/lib/bettercap/sniffer/parsers/redis.rb
@@ -19,16 +19,16 @@ class Redis < Base
     @name = 'REDIS'
   end
   def on_packet( pkt )
-    if pkt.tcp_dst == 6379
-      lines = pkt.to_s.split(/\r?\n/)
-      lines.each do |line|
-        if line =~ /config\s+set\s+requirepass\s+(.+)$/i
-          pass = "#{$1}"
-          StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
-        elsif line =~ /AUTH\s+(.+)$/i
-          pass = "#{$1}"
-          StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
-        end
+    return unless pkt.tcp_dst == 6379
+
+    lines = pkt.to_s.split(/\r?\n/)
+    lines.each do |line|
+      if line =~ /config\s+set\s+requirepass\s+(.+)$/i
+        pass = "#{$1}"
+        StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
+      elsif line =~ /AUTH\s+(.+)$/i
+        pass = "#{$1}"
+        StreamLogger.log_raw( pkt, @name, "password=#{pass}" )
       end
     end
   rescue

--- a/lib/bettercap/sniffer/parsers/rlogin.rb
+++ b/lib/bettercap/sniffer/parsers/rlogin.rb
@@ -19,23 +19,22 @@ class Rlogin < Base
     @name = 'RLOGIN'
   end
   def on_packet( pkt )
-    if pkt.tcp_dst == 513
-      # rlogin packet data = 0x00[client-username]0x00<server-username>0x00<terminal/speed>0x00
+    return unless pkt.tcp_dst == 513
+    # rlogin packet data = 0x00[client-username]0x00<server-username>0x00<terminal/speed>0x00
 
-      # if client username, server username and terminal/speed were supplied...
-      # regex starts at client username as the first null byte is stripped from pkt.payload.to_s
-      if pkt.payload.to_s =~ /\A([a-z0-9_-]+)\x00([a-z0-9_-]+)\x00([a-z0-9_-]+\/[0-9]+)\x00\Z/i
-        client_user = $1
-        server_user = $2
-        terminal = $3
-        StreamLogger.log_raw( pkt, @name, "client-username=#{client_user} server-username=#{server_user} terminal=#{terminal}" )
-      # else, if only server username and terminal/speed were supplied...
-      # regex starts at 0x00 as the first null byte is stripped from pkt.payload.to_s and the client username is empty
-      elsif pkt.payload.to_s =~ /\A\x00([a-z0-9_-]+)\x00([a-z0-9_-]+\/[0-9]+)\x00\Z/i
-        server_user = $1
-        terminal = $2
-        StreamLogger.log_raw( pkt, @name, "server-username=#{server_user} terminal=#{terminal}" )
-      end
+    # if client username, server username and terminal/speed were supplied...
+    # regex starts at client username as the first null byte is stripped from pkt.payload.to_s
+    if pkt.payload.to_s =~ /\A([a-z0-9_-]+)\x00([a-z0-9_-]+)\x00([a-z0-9_-]+\/[0-9]+)\x00\Z/i
+      client_user = $1
+      server_user = $2
+      terminal = $3
+      StreamLogger.log_raw( pkt, @name, "client-username=#{client_user} server-username=#{server_user} terminal=#{terminal}" )
+    # else, if only server username and terminal/speed were supplied...
+    # regex starts at 0x00 as the first null byte is stripped from pkt.payload.to_s and the client username is empty
+    elsif pkt.payload.to_s =~ /\A\x00([a-z0-9_-]+)\x00([a-z0-9_-]+\/[0-9]+)\x00\Z/i
+      server_user = $1
+      terminal = $2
+      StreamLogger.log_raw( pkt, @name, "server-username=#{server_user} terminal=#{terminal}" )
     end
   rescue
   end

--- a/lib/bettercap/sniffer/parsers/snmp.rb
+++ b/lib/bettercap/sniffer/parsers/snmp.rb
@@ -22,21 +22,21 @@ module Parsers
 # SNMP community string parser.
 class SNMP < Base
   def on_packet( pkt )
-    if pkt.udp_dst == 161
-      packet = Network::Protos::SNMP::Packet.parse( pkt.payload )
+    return unless pkt.udp_dst == 161
 
-      unless packet.nil?
-        if packet.snmp_version_number.to_i == 0
-          snmp_version = 'v1'
-        else
-          snmp_version = 'n/a'
-        end
+    packet = Network::Protos::SNMP::Packet.parse( pkt.payload )
 
-        msg = "[#{'Version:'.green} #{snmp_version}] [#{'Community:'.green} #{packet.snmp_community_string.map { |x| x.chr }.join.yellow}]"
+    return if packet.nil?
 
-        StreamLogger.log_raw( pkt, 'SNMP', msg )
-      end
+    if packet.snmp_version_number.to_i == 0
+      snmp_version = 'v1'
+    else
+      snmp_version = 'n/a'
     end
+
+    msg = "[#{'Version:'.green} #{snmp_version}] [#{'Community:'.green} #{packet.snmp_community_string.map { |x| x.chr }.join.yellow}]"
+
+    StreamLogger.log_raw( pkt, 'SNMP', msg )
   rescue
   end
 end

--- a/lib/bettercap/sniffer/parsers/snpp.rb
+++ b/lib/bettercap/sniffer/parsers/snpp.rb
@@ -19,14 +19,14 @@ class Snpp < Base
     @name = 'SNPP'
   end
   def on_packet( pkt )
-    if pkt.tcp_dst == 444
-      lines = pkt.to_s.split(/\r?\n/)
-      lines.each do |line|
-        if line =~ /LOGIn\s+(.+)\s+(.+)$/
-          user = $1
-          pass = $2
-          StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
-        end
+    return unless pkt.tcp_dst == 444
+
+    lines = pkt.to_s.split(/\r?\n/)
+    lines.each do |line|
+      if line =~ /LOGIn\s+(.+)\s+(.+)$/
+        user = $1
+        pass = $2
+        StreamLogger.log_raw( pkt, @name, "username=#{user} password=#{pass}" )
       end
     end
   rescue

--- a/lib/bettercap/sniffer/parsers/teamtalk.rb
+++ b/lib/bettercap/sniffer/parsers/teamtalk.rb
@@ -18,18 +18,17 @@ class TeamTalk < Base
     @name = 'TeamTalk'
   end
   def on_packet( pkt )
-    if pkt.tcp_dst == 10333 || pkt.udp_dst == 10333
-      lines = pkt.to_s.split(/\r?\n/)
-      lines.each do |line|
-        if line =~ /login\s+/
-          if line =~ /username=/ && line =~ /password=/
-            version = line.scan(/version="?([\d\.]+)"?\s/).flatten.first
-            user = line.scan(/username="?(.*?)"?\s/).flatten.first
-            pass = line.scan(/password="?(.*?)"?\s/).flatten.first
-            StreamLogger.log_raw( pkt, @name, "#{'version'.blue}=#{version} username=#{user} password=#{pass}" )
-          end
-        end
-      end
+    return unless (pkt.tcp_dst == 10333 || pkt.udp_dst == 10333)
+
+    lines = pkt.to_s.split(/\r?\n/)
+    lines.each do |line|
+      next unless (line =~ /login\s+/ && line =~ /username=/ && line =~ /password=/)
+
+      version = line.scan(/version="?([\d\.]+)"?\s/).flatten.first
+      user = line.scan(/username="?(.*?)"?\s/).flatten.first
+      pass = line.scan(/password="?(.*?)"?\s/).flatten.first
+
+      StreamLogger.log_raw( pkt, @name, "#{'version'.blue}=#{version} username=#{user} password=#{pass}" )
     end
   rescue
   end

--- a/lib/bettercap/sniffer/parsers/teamviewer.rb
+++ b/lib/bettercap/sniffer/parsers/teamviewer.rb
@@ -16,12 +16,13 @@ module Parsers
 # MySQL authentication parser.
 class TeamViewer < Base
   def on_packet( pkt )
-    if pkt.tcp_dst == 5938 or pkt.tcp_src == 5938
-      packet = Network::Protos::TeamViewer::Packet.parse( pkt.payload )
-      unless packet.nil?
-        StreamLogger.log_raw( pkt, 'TEAMVIEWER', "#{'version'.blue}=#{packet.version.yellow} #{'command'.blue}=#{packet.command.yellow}"  )
-      end
-    end
+    return unless (pkt.tcp_dst == 5938 || pkt.tcp_src == 5938)
+
+    packet = Network::Protos::TeamViewer::Packet.parse( pkt.payload )
+
+    return if packet.nil?
+
+    StreamLogger.log_raw( pkt, 'TEAMVIEWER', "#{'version'.blue}=#{packet.version.yellow} #{'command'.blue}=#{packet.command.yellow}"  )
   rescue
   end
 end

--- a/lib/bettercap/sniffer/parsers/url.rb
+++ b/lib/bettercap/sniffer/parsers/url.rb
@@ -17,12 +17,12 @@ module Parsers
 class Url < Base
   def on_packet( pkt )
     s = pkt.to_s
-    if s =~ /GET\s+([^\s]+)\s+HTTP.+Host:\s+([^\s]+).+/m
-      host = $2
-      url = $1
-      unless url =~ /.+\.(png|jpg|jpeg|bmp|gif|img|ttf|woff|css|js).*/i
-        StreamLogger.log_raw( pkt, 'GET', "http://#{host}#{url}" )
-      end
+    return unless s =~ /GET\s+([^\s]+)\s+HTTP.+Host:\s+([^\s]+).+/m
+
+    host = $2
+    url = $1
+    unless url =~ /.+\.(png|jpg|jpeg|bmp|gif|img|ttf|woff|css|js).*/i
+      StreamLogger.log_raw( pkt, 'GET', "http://#{host}#{url}" )
     end
   end
 end


### PR DESCRIPTION
Minor code cleanup; uses `return unless` guard clause syntax in sniffers, rather than traditional `if` conditional blocks.

Keeps the code closer to the left margin.

Results in slightly smaller file sizes.
