### PR TITLE
Slight cosmetic change

### DIFF
--- a/lib/bettercap/proxy/stream_logger.rb
+++ b/lib/bettercap/proxy/stream_logger.rb
@@ -190,7 +190,7 @@ class StreamLogger
   # with the +request+ and +response+ most important informations.
   def self.log_http( request, response )
     response_s = ""
-    response_s += " ( #{response.content_type} )" unless response.content_type.nil?
+    response_s += " ( #{response.content_type} )".light_black unless response.content_type.nil?
     request_s  = request.to_url( nil )
     code       = response.code.to_s[0]
 

--- a/lib/bettercap/sniffer/parsers/url.rb
+++ b/lib/bettercap/sniffer/parsers/url.rb
@@ -22,7 +22,7 @@ class Url < Base
     host = $2
     url = $1
     unless url =~ /.+\.(png|jpg|jpeg|bmp|gif|img|ttf|woff|css|js).*/i
-      StreamLogger.log_raw( pkt, 'GET', "http://#{host}#{url}" )
+      StreamLogger.log_raw( pkt, 'GET', "#{'⚫'.red}http://#{host}#{url}" )
     end
   end
 end


### PR DESCRIPTION
Sometimes I need to see both HTTP & HTTPS traffic, and it gets hard for me to tell the two apart. I overcome this issue by adding a red ⚫ to indicate unencrypted traffic (see screenshot below)

The content-type tag is easier to spot as well with this change.

![screenshot from 2017-08-17 23-11-37](https://user-images.githubusercontent.com/29265684/29414928-ac79321e-83a4-11e7-8e4b-da8d682b0282.png)
