### PR TITLE
PR-1 Increased Content-Type visibility (cosmetic)

### DIFF
--- a/lib/bettercap/proxy/stream_logger.rb
+++ b/lib/bettercap/proxy/stream_logger.rb
@@ -190,7 +190,7 @@ class StreamLogger
   # with the +request+ and +response+ most important informations.
   def self.log_http( request, response )
     response_s = ""
-    response_s += " ( #{response.content_type} )" unless response.content_type.nil?
+    response_s += " ( #{response.content_type} )".light_black unless response.content_type.nil?
     request_s  = request.to_url( nil )
     code       = response.code.to_s[0]
 


### PR DESCRIPTION
I made 2 different pull requests for these changes (but the screenshots show both)

**PR 1 (this one)**
- Increased the contrast of `( Content-Type )` logs

**PR 2**
I couldn't find a good way to implement the 🔒 for encrypted traffic as I understand that different OS have other symbols for this character code (or don't have any)
- Changed `[PROTOCOL]` parser colors to distinguish encrypted from non-encrypted traffic more easily
- CHANGED `[GET]` protocol parser to `[HTTP]` for urls
- Made code a bit more consistent

Pics

![screenshot from 2017-08-18 23-37-27](https://user-images.githubusercontent.com/29265684/29481669-46616216-84c7-11e7-89f3-fc873114ef20.png)
![screenshot from 2017-08-19 09-05-24](https://user-images.githubusercontent.com/29265684/29481670-494831b2-84c7-11e7-8de0-fb84d272c341.png)
