### PR TITLE
PR-2 Changed [GET] protocol parser to [HTTP] + Changed [PROTOCOL] parser colors to distinguish encrypted from non-encrypted traffic more easily (cosmetic)

### DIFF
--- a/lib/bettercap/proxy/stream_logger.rb
+++ b/lib/bettercap/proxy/stream_logger.rb
@@ -67,7 +67,7 @@ class StreamLogger
   # Log a raw packet ( +pkt+ ) data +payload+ using the specified +label+.
   def self.log_raw( pkt, label, payload )
     nl    = label.include?("\n") ? "\n" : " "
-    label = label.strip
+    label = label.strip == 'HTTPS' ? label.strip.green : label.strip.yellow
     from  = self.addr2s( pkt.ip_saddr, pkt.eth2s(:src) )
     to    = self.addr2s( pkt.ip_daddr, pkt.eth2s(:dst) )
 
@@ -77,7 +77,7 @@ class StreamLogger
       to += ':' + self.service( :udp, pkt.udp_dst ).to_s.light_blue
     end
 
-    Logger.raw( "[#{from} > #{to}] [#{label.green}]#{nl}#{payload.strip}" )
+    Logger.raw( "[#{from} > #{to}] [#{label}]#{nl}#{payload.strip}" )
   end
 
   def self.dump_form( request )

--- a/lib/bettercap/sniffer/parsers/cookie.rb
+++ b/lib/bettercap/sniffer/parsers/cookie.rb
@@ -76,7 +76,7 @@ class Cookie < Base
 
     unless hostname.nil? or cookies.empty?
       unless @jar.known_cookie?( pkt.ip_saddr, hostname, cookies )
-        StreamLogger.log_raw( pkt, "COOKIE", "[#{hostname.yellow}] #{cookies.map{|k,v| "#{k.green}=#{v.yellow}"}.join('; ')}" )
+        StreamLogger.log_raw( pkt, 'COOKIE', "[#{hostname.yellow}] #{cookies.map{|k,v| "#{k.green}=#{v.yellow}"}.join('; ')}" )
         @jar.store( pkt.ip_saddr, hostname, cookies )
       end
     end

--- a/lib/bettercap/sniffer/parsers/post.rb
+++ b/lib/bettercap/sniffer/parsers/post.rb
@@ -22,7 +22,7 @@ class Post < Base
     req = BetterCap::Proxy::HTTP::Request.parse(pkt.payload)
     # the packet could be incomplete
     unless req.body.nil? or req.body.empty?
-      StreamLogger.log_raw( pkt, "POST", req.to_url(1000) )
+      StreamLogger.log_raw( pkt, 'POST', req.to_url(1000) )
       StreamLogger.log_post( req )
     end
   rescue

--- a/lib/bettercap/sniffer/parsers/url.rb
+++ b/lib/bettercap/sniffer/parsers/url.rb
@@ -22,7 +22,7 @@ class Url < Base
     host = $2
     url = $1
     unless url =~ /.+\.(png|jpg|jpeg|bmp|gif|img|ttf|woff|css|js).*/i
-      StreamLogger.log_raw( pkt, 'GET', "http://#{host}#{url}" )
+      StreamLogger.log_raw( pkt, 'HTTP', "http://#{host}#{url}" )
     end
   end
 end


### PR DESCRIPTION
I made 2 different pull requests for these changes (but the screenshots show both)

**PR 1**
- Increased the contrast of `( Content-Type )` logs

**PR 2 (this one)**
I couldn't find a good way to implement the 🔒 for encrypted traffic as I understand that different OS have other symbols for this character code (or don't have any)
- Changed `[PROTOCOL]` parser colors to distinguish encrypted from non-encrypted traffic more easily
- CHANGED `[GET]` protocol parser to `[HTTP]` for urls
- Made code a bit more consistent

Pics

![screenshot from 2017-08-18 23-37-27](https://user-images.githubusercontent.com/29265684/29481669-46616216-84c7-11e7-89f3-fc873114ef20.png)
![screenshot from 2017-08-19 09-05-24](https://user-images.githubusercontent.com/29265684/29481670-494831b2-84c7-11e7-8de0-fb84d272c341.png)
