### PR TITLE
Use HTTPS links in documentation

### DIFF
--- a/bin/bettercap
+++ b/bin/bettercap
@@ -7,7 +7,7 @@
 
   Author : Simone 'evilsocket' Margaritelli
   Email  : evilsocket@gmail.com
-  Blog   : http://www.evilsocket.net/
+  Blog   : https://www.evilsocket.net/
 
   This project is released under the GPL 3 license.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -45,6 +45,6 @@ If your answer is "ettercap", let me tell you something:
 
 Moreover:
 
-* Ettercap's and MITMf's ICMP spoofing is completely useless, [ours is not](http://www.evilsocket.net/2016/01/10/bettercap-and-the-first-real-icmp-redirect-attack/).
+* Ettercap's and MITMf's ICMP spoofing is completely useless, [ours is not](https://www.evilsocket.net/2016/01/10/bettercap-and-the-first-real-icmp-redirect-attack/).
 * Ettercap does **not** provide a builtin and modular HTTP(S) and TCP transparent proxies, we do.
 * Ettercap does **not** provide a smart and fully customizable credentials sniffer, we do.

--- a/lib/bettercap/proxy/http/modules/redirect.rb
+++ b/lib/bettercap/proxy/http/modules/redirect.rb
@@ -5,7 +5,7 @@ BETTERCAP
 
 Author : Simone 'evilsocket' Margaritelli
 Email  : evilsocket@gmail.com
-Blog   : http://www.evilsocket.net/
+Blog   : https://www.evilsocket.net/
 
 This project is released under the GPL 3 license.
 

--- a/lib/bettercap/sniffer/parsers/nntp.rb
+++ b/lib/bettercap/sniffer/parsers/nntp.rb
@@ -5,7 +5,7 @@ BETTERCAP
 
 Author : Simone 'evilsocket' Margaritelli
 Email  : evilsocket@gmail.com
-Blog   : http://www.evilsocket.net/
+Blog   : https://www.evilsocket.net/
 
 NNTP authentication parser:
   Author : Brendan Coles


### PR DESCRIPTION
I hear using HTTPS hinders MitM attacks.
