### PR TITLE
Add sniffer/parser/NTP

### DIFF
--- a/lib/bettercap/sniffer/parsers/ntp.rb
+++ b/lib/bettercap/sniffer/parsers/ntp.rb
@@ -1,0 +1,136 @@
+# encoding: UTF-8
+=begin
+
+BETTERCAP
+
+Author : Simone 'evilsocket' Margaritelli
+Email  : evilsocket@gmail.com
+Blog   : https://www.evilsocket.net/
+
+NTP packet and authentication parser:
+  Author : Brendan Coles
+  Email  : bcoles[at]gmail.com
+
+This project is released under the GPL 3 license.
+
+=end
+
+module BetterCap
+module Parsers
+#
+# NTP packet and authentication parser.
+#
+# Supports NTP version 4
+# Supports IPv4
+# Supports MD5 authentication
+#
+# Does not support IPv6
+# Does not support NTP version 3
+# Does not support SHA1 authentication
+#
+# References:
+# - https://en.wikipedia.org/wiki/Network_Time_Protocol
+# - https://wiki.wireshark.org/NTP
+# - https://tools.ietf.org/html/rfc1305
+# - https://tools.ietf.org/html/rfc5905
+# - https://tools.ietf.org/html/rfc7822
+#
+class Ntp < Base
+  def initialize
+    @name = 'NTP'
+  end
+
+  def on_packet( pkt )
+    # We're only interested in NTP packets with MD5 authentication data
+    return unless ( pkt.respond_to?('udp_src') && pkt.respond_to?('udp_dst') && \
+                    ( pkt.udp_src == 123 || pkt.udp_dst == 123 ) && \
+                    pkt.payload.length == 68 )
+
+    log = []
+    data = pkt.payload.to_s.unpack('H*').first
+
+=begin
+
+Packet format from RFC5905, section 7.3:
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |LI | VN  |Mode |    Stratum     |     Poll      |  Precision   |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                         Root Delay                            |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                         Root Dispersion                       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                          Reference ID                         |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                     Reference Timestamp (64)                  +
+      |                                                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                      Origin Timestamp (64)                    +
+      |                                                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                      Receive Timestamp (64)                   +
+      |                                                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                      Transmit Timestamp (64)                  +
+      |                                                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      .                                                               .
+      .                    Extension Field 1 (variable)               .
+      .                                                               .
+      |                                                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      .                                                               .
+      .                    Extension Field 2 (variable)               .
+      .                                                               .
+      |                                                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                          Key Identifier                       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      |                            dgst (128)                         |
+      |                                                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+=end
+
+    # NTP packet headers, excluding key ID and key digest
+    salt = data[0...-40]
+    log << "#{'Salt'.blue}=#{salt}"
+
+    # Key ID
+    key_id = data[-40...-32].to_i(16)
+    log << " #{'KeyID'.blue}=#{key_id}"
+
+    # MD5 digest
+    key = data[-32..-1]
+    log << "#{'Digest'.blue}=#{key}"
+
+    # Check for weak passwords
+    # Note: Uncomment to enable cracking of weak passwords.
+    #       Note that this could cause performance issues.
+=begin
+    ['secret', 'password', '123456', 'ntp', 'ntp123', 'ntp1234', 'ntp12345', 'foobar'].each do |password|
+      md5 = Digest::MD5.new
+      md5.update "#{password}#{[salt].pack('H*')}"
+
+      if md5.hexdigest.to_s == key
+        log << "('#{password.yellow}')"
+        break
+      end
+    end
+=end
+
+    StreamLogger.log_raw pkt, @name, log.join(' ')
+  rescue
+  end
+end
+end
+end


### PR DESCRIPTION
This PR adds a [Network Time Protocol (NTP)](https://en.wikipedia.org/wiki/Network_Time_Protocol) packet and authentication parser.

![ntp](https://user-images.githubusercontent.com/434827/30001222-a0e26460-90ca-11e7-878a-8f241382c36f.png)

## Summary

* Supports NTP version 4
* Supports IPv4
* Supports MD5 authentication

* Does not support IPv6
* Does not support NTP version 3
* Does not support SHA1 authentication


## Description

It turns out the NTP protocol is a mess (no offense, Dr. Mills) and I got bored with it quickly.

As far as I can tell, there's nothing in the header to indicate whether authentication digest is present. There are no delimiters or length fields from which to easily calculate the offset of the authentication data. As a result, the entire packet (of which there are several packet types of variable length) needs to be parsed before identifying the presence of authentication data which is tacked on the end of the packet with little to no warning.

As a result, I took the lazy approach which significantly decreases the usefulness of this parser. There's plenty of room for improvement for someone more motivated.

To eliminate false positives (hopefully) this parser works only for packets of a specific length (`pkt.payload.length == 68`). As a result, it supports only MD5 authentication - not SHA1.

If the target `pkt` matches the above requirements, the parser extracts and displays the Key ID, MD5 Hash, and the salt. (The salt is the entirety of the packet, excluding the Key ID and MD5 Hash.)


## Sample output

```
[I] [SNIFFER] Reading packets from /pentest/mitm/bettercap/pcap/ntp/sample-1.pcap ...
[127.0.0.1 > 127.0.0.1:ntp] [NTP] Salt=e30003fa000100000001000000000000000000000000000000000000000000000000000000000000d7dd1057213ad63b  KeyID=1 Digest=0c9abcb1f0dd33cda71f5138b4f7b96c ('secret')
[127.0.0.1 > 127.0.0.1:ntp] [NTP] Salt=e30003fa000100000001000000000000000000000000000000000000000000000000000000000000d7dd1059213a69a2  KeyID=1 Digest=505d611e103aace6823eccd7909f5891 ('secret')
[127.0.0.1 > 127.0.0.1:ntp] [NTP] Salt=e30003fa000100000001000000000000000000000000000000000000000000000000000000000000d7dd1060ee06bec2  KeyID=1 Digest=08e3ded271f83affc8f127dae3cb5bed ('secret')
[I] [SNIFFER] 3 packets processed in 100.751379 ms ( 0 skipped packets, 3 processed packets )
```


## Testing

Tested with PCAPs:

* https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=NTP_sync.pcap
* https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=NTP_with_MD5_key_foobar.pcap
* https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=MicrosoftNTP.cap
* https://github.com/kholia/my-pcaps/blob/master/NTP/NTP-mixed-hashes-2.pcap
* https://github.com/kholia/my-pcaps/blob/master/NTP/NTP-mixed-hashes.pcap
* https://github.com/kholia/my-pcaps/blob/master/NTP/sample-1.pcap


## Cracking

I've included rudimentary password cracking functionality to crack weak passwords, however this functionality is commented out. My thinking is that regularly performing computationally expensive operations on UDP traffic could cause performance issues and result in denial of service if someone were to spam NTP UDP packets.

Here's an example standalone program which can crack NTP with MD5 authentication, based on the salt + md5.

```ruby
#!/usr/bin/env ruby
# Crack NTP MD5 authentication
# ~ bcoles
require 'digest/md5'

salt = '230000000000000c0000000000000000000000000000000000000000000000000000000000000000cc25cc132b021000'
key = '52800c2b5900646684f44ca4eece12b8'

words = ['secret', 'password', '123456', 'ntp', 'ntp123', 'ntp1234', 'ntp12345', 'foobar']

words.each do |password|
  md5 = Digest::MD5.new
  md5.update "#{password}#{[salt].pack('H*')}"

  if md5.hexdigest.to_s == key
    puts "Found password: #{password}"
    break
  end
end
```
