### PR TITLE
Add a 'maximum number of times to inject' option.

### DIFF
--- a/lib/bettercap/proxy/http/modules/injectcss.rb
+++ b/lib/bettercap/proxy/http/modules/injectcss.rb
@@ -25,6 +25,10 @@ class InjectCSS < BetterCap::Proxy::HTTP::Module
   @@cssdata = nil
   # CSS file URL to be injected.
   @@cssurl  = nil
+  # Maximum number of times to inject.
+  @@max = 1000000
+  # Counter for the number of injections.
+  @@cnt = 0
 
   # Add custom command line arguments to the +opts+ OptionParser instance.
   def self.on_options(opts)
@@ -51,6 +55,10 @@ class InjectCSS < BetterCap::Proxy::HTTP::Module
     opts.on( '--css-url URL', 'URL the CSS file to be injected.' ) do |v|
       @@cssurl = v
     end
+
+    opts.on( '--css-max NUM', 'Maximum number of times to inject.' ) do |v|
+      @@max = v.to_i
+    end
   end
 
   # Create an instance of this module and raise a BetterCap::Error if command
@@ -63,7 +71,8 @@ class InjectCSS < BetterCap::Proxy::HTTP::Module
   # +response+.
   def on_request( request, response )
     # is it a html page?
-    if response.content_type =~ /^text\/html.*/
+    if response.content_type =~ /^text\/html.*/ and ( @@cnt < @@max )
+      @@cnt += 1
       BetterCap::Logger.info "[#{'INJECTCSS'.green}] Injecting CSS #{@@cssdata.nil?? "URL" : "file"} into #{request.to_url}"
       # inject URL
       if @@cssdata.nil?

--- a/lib/bettercap/proxy/http/modules/injecthtml.rb
+++ b/lib/bettercap/proxy/http/modules/injecthtml.rb
@@ -27,6 +27,10 @@ class InjectHTML < BetterCap::Proxy::HTTP::Module
   @@data = nil
   # Position of the injection, 0 = just after <body>, 1 = before </body>
   @@position = 0
+  # Maximum number of times to inject.
+  @@max = 1000000
+  # Counter for the number of injections.
+  @@cnt = 0
 
   # Add custom command line arguments to the +opts+ OptionParser instance.
   def self.on_options(opts)
@@ -57,6 +61,10 @@ class InjectHTML < BetterCap::Proxy::HTTP::Module
         raise BetterCap::Error, "#{v} invalid position, only START or END values are accepted."
       end
     end
+
+    opts.on( '--html-max NUM', 'Maximum number of times to inject.' ) do |v|
+      @@max = v.to_i
+    end
   end
 
   # Create an instance of this module and raise a BetterCap::Error if command
@@ -69,7 +77,8 @@ class InjectHTML < BetterCap::Proxy::HTTP::Module
   # +response+.
   def on_request( request, response )
     # is it a html page?
-    if response.content_type =~ /^text\/html.*/
+    if response.content_type =~ /^text\/html.*/ and ( @@cnt < @@max )
+      @@cnt += 1
       BetterCap::Logger.info "[#{'INJECTHTML'.green}] Injecting HTML code into #{request.to_url}"
 
       if @@data.nil?

--- a/lib/bettercap/proxy/http/modules/injectjs.rb
+++ b/lib/bettercap/proxy/http/modules/injectjs.rb
@@ -25,6 +25,10 @@ class InjectJS < BetterCap::Proxy::HTTP::Module
   @@jsdata = nil
   # JS file URL to be injected.
   @@jsurl  = nil
+  # Maximum number of times to inject.
+  @@max = 1000000
+  # Counter for the number of injections.
+  @@cnt = 0
 
   # Add custom command line arguments to the +opts+ OptionParser instance.
   def self.on_options(opts)
@@ -51,6 +55,10 @@ class InjectJS < BetterCap::Proxy::HTTP::Module
     opts.on( '--js-url URL', 'URL the javascript file to be injected.' ) do |v|
       @@jsurl = v
     end
+
+    opts.on( '--js-max NUM', 'Maximum number of times to inject.' ) do |v|
+      @@max = v.to_i
+    end
   end
 
   # Create an instance of this module and raise a BetterCap::Error if command
@@ -63,7 +71,8 @@ class InjectJS < BetterCap::Proxy::HTTP::Module
   # +response+.
   def on_request( request, response )
     # is it a html page?
-    if response.content_type =~ /^text\/html.*/
+    if response.content_type =~ /^text\/html.*/ and ( @@cnt < @@max )
+      @@cnt += 1
       BetterCap::Logger.info "[#{'INJECTJS'.green}] Injecting javascript #{@@jsdata.nil?? "URL" : "file"} into #{request.to_url}"
       # inject URL
       if @@jsdata.nil?


### PR DESCRIPTION
When using the http proxy modules (injectcss, injectjs, and injecthtml) you can independently limit the number of times the injection occurs via the --css-max, --js-max, and --html-max options.